### PR TITLE
Fix "restart as admin" message

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -31,14 +31,14 @@ function activate(context) {
       const htmlFile =
         base +
         (isWin
-          ? "\\electron-browser\\workbench\\workbench.html"
-          : "/electron-browser/workbench/workbench.html");
+          ? "\\electron-sandbox\\workbench\\workbench.html"
+          : "/electron-sandbox/workbench/workbench.html");
 
       const templateFile =
         base +
         (isWin
-          ? "\\electron-browser\\workbench\\neondreams.js"
-          : "/electron-browser/workbench/neondreams.js");
+          ? "\\electron-sandbox\\workbench\\neondreams.js"
+          : "/electron-sandbox/workbench/neondreams.js");
       try {
         // const version = context.globalState.get(`${context.extensionName}.version`);
 
@@ -142,8 +142,8 @@ function uninstall() {
 	var htmlFile =
 		base +
 		(isWin
-			? "\\electron-browser\\workbench\\workbench.html"
-			: "/electron-browser/workbench/workbench.html");
+			? "\\electron-sandbox\\workbench\\workbench.html"
+			: "/electron-sandbox/workbench/workbench.html");
 
 	// modify workbench html
 	const html = fs.readFileSync(htmlFile, "utf-8");


### PR DESCRIPTION
Fix repeated prompt to restart as admin when trying to enable neon glow.