### PR TITLE
Update extension.js

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -31,14 +31,14 @@ function activate(context) {
       const htmlFile =
         base +
         (isWin
-          ? "\\electron-browser\\workbench\\workbench.html"
-          : "/electron-browser/workbench/workbench.html");
+          ? "\\electron-sandbox\\workbench\\workbench.html"
+          : "/electron-sandbox/workbench/workbench.html");
 
       const templateFile =
         base +
         (isWin
-          ? "\\electron-browser\\workbench\\neondreams.js"
-          : "/electron-browser/workbench/neondreams.js");
+          ? "\\electron-sandbox\\workbench\\neondreams.js"
+          : "/electron-sandbox/workbench/neondreams.js");
       try {
         // const version = context.globalState.get(`${context.extensionName}.version`);
 


### PR DESCRIPTION
I've tried this change in the code to enable the glow on my computer. When I was trying to enable the glow, VS Code send me this message "You must run VS code with admin privileges in order to enable Neon Dreams.". Looking for it on the Ethernet, I found this option proposed by the user @pulberg on https://github.com/robb0wen/synthwave-vscode/issues/263